### PR TITLE
[FEAT] CRUD de Categorias (rotas protegidas)

### DIFF
--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -3,6 +3,9 @@ import Login from "@pages/Login";
 import Register from "@pages/Register";
 import Home from "@pages/Home";
 import { ProtectedRoute } from "@lib/router/ProtectedRoute";
+import CategoriesList from "@pages/categories/CategoriesList";
+import CategoryCreate from "@pages/categories/CategoryCreate";
+import CategoryEdit from "@pages/categories/CategoryEdit";
 
 export function AppRoutes() {
   return (
@@ -22,9 +25,35 @@ export function AppRoutes() {
           }
         />
 
+        <Route
+          path="/categories"
+          element={
+            <ProtectedRoute>
+              <CategoriesList />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/categories/new"
+          element={
+            <ProtectedRoute>
+              <CategoryCreate />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/categories/:id/edit"
+          element={
+            <ProtectedRoute>
+              <CategoryEdit />
+            </ProtectedRoute>
+          }
+        />
+
         {/* fallback */}
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </BrowserRouter>
   );
 }
+

--- a/frontend/src/components/ui/forms/CategoryForm.tsx
+++ b/frontend/src/components/ui/forms/CategoryForm.tsx
@@ -1,0 +1,42 @@
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import type { CategoryInput } from "types/category";
+import { Button } from "@components/ui/button";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+// import { Textarea } from "@components/ui/textarea"; // se não tiver, use <textarea className="...">
+
+const schema = z.object({
+  name: z.string().min(2, "Informe o nome"),
+  description: z.string().optional(),
+});
+type FormData = z.infer<typeof schema>;
+
+type Props = {
+  defaultValues?: Partial<CategoryInput>;
+  onSubmit: (data: CategoryInput) => void | Promise<void>;
+  submitting?: boolean;
+  submitLabel?: string;
+};
+
+export function CategoryForm({ defaultValues, onSubmit, submitting, submitLabel = "Salvar" }: Props) {
+  const { register, handleSubmit, formState: { errors } } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues,
+  });
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <div className="space-y-2">
+        <Label>Nome</Label>
+        <Input {...register("name")} placeholder="Ex: Eletrônicos" />
+        {errors.name && <p className="text-sm text-red-500">{errors.name.message}</p>}
+      </div>
+
+      <Button type="submit" disabled={submitting} className="w-full">
+        {submitting ? "Enviando..." : submitLabel}
+      </Button>
+    </form>
+  );
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 import { useAuthStore } from "@stores/authStore";
 import { Button } from "@components/ui/button";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 
 export default function Home() {
   const user = useAuthStore((s) => s.user);
@@ -10,6 +10,7 @@ export default function Home() {
   return (
     <div className="min-h-screen grid place-items-center p-6 text-center space-y-4">
       <h1 className="text-2xl font-semibold">Bem-vindo{user ? `, ${user.name}` : ""}!</h1>
+      <Button asChild><Link to="/categories">Ir para categorias</Link></Button>
       <Button
         variant="outline"
         onClick={() => {

--- a/frontend/src/pages/categories/CategoriesList.tsx
+++ b/frontend/src/pages/categories/CategoriesList.tsx
@@ -1,0 +1,72 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { listCategories, deleteCategory } from "@services/categories";
+import { Link, useNavigate } from "react-router-dom";
+import { Button } from "@components/ui/button";
+
+export default function CategoriesList() {
+  const qc = useQueryClient();
+  const nav = useNavigate();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["categories"],
+    queryFn: listCategories,
+  });
+
+  const { mutateAsync: remove, isPending: removing } = useMutation({
+    mutationFn: (id: string | number) => deleteCategory(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["categories"] }),
+  });
+
+  if (isLoading) return <p className="p-4">Carregando...</p>;
+  if (error) return <p className="p-4 text-red-500">Erro ao carregar categorias</p>;
+
+  return (
+    <div className="p-6 space-y-4 max-w-3xl mx-auto">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Categorias</h1>
+        <Button onClick={() => nav("/categories/new")}>Nova categoria</Button>
+      </div>
+
+      {!data?.length ? (
+        <p className="text-sm text-muted-foreground">Nenhuma categoria cadastrada.</p>
+      ) : (
+        <div className="overflow-x-auto border rounded-lg">
+          <table className="w-full text-left">
+            <thead className="bg-muted/40">
+              <tr>
+                <th className="p-3">ID</th>
+                <th className="p-3">Nome</th>
+                <th className="p-3 w-48">Ações</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.map((c) => (
+                <tr key={c.id} className="border-t">
+                  <td className="p-3">{c.id}</td>
+                  <td className="p-3">{c.name}</td>
+                  <td className="p-3 space-x-2">
+                    <Button variant="outline" size="sm" asChild>
+                      <Link to={`/categories/${c.id}/edit`}>Editar</Link>
+                    </Button>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      disabled={removing}
+                      onClick={async () => {
+                        if (confirm(`Excluir categoria "${c.name}"?`)) {
+                          await remove(c.id);
+                        }
+                      }}
+                    >
+                      Excluir
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/categories/CategoryCreate.tsx
+++ b/frontend/src/pages/categories/CategoryCreate.tsx
@@ -1,0 +1,30 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createCategory } from "@services/categories";
+import { useNavigate } from "react-router-dom";
+import { CategoryForm } from "@components/ui/forms/CategoryForm";
+
+export default function CategoryCreate() {
+  const qc = useQueryClient();
+  const nav = useNavigate();
+
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: createCategory,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["categories"] });
+      nav("/categories");
+    },
+  });
+
+  return (
+    <div className="p-6 max-w-lg mx-auto space-y-4">
+      <h1 className="text-2xl font-semibold">Nova categoria</h1>
+      <CategoryForm
+        submitting={isPending}
+        onSubmit={async (data) => {
+          await mutateAsync(data);
+        }}
+        submitLabel="Criar"
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/categories/CategoryEdit.tsx
+++ b/frontend/src/pages/categories/CategoryEdit.tsx
@@ -1,0 +1,40 @@
+import { useParams, useNavigate } from "react-router-dom";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getCategory, updateCategory } from "@services/categories";
+import { CategoryForm } from "@components/ui/forms/CategoryForm";
+
+export default function CategoryEdit() {
+  const { id = "" } = useParams();
+  const nav = useNavigate();
+  const qc = useQueryClient();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["category", id],
+    queryFn: () => getCategory(id),
+  });
+
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: (input: { id: string | number; name: string; description?: string }) =>
+      updateCategory(input.id, { name: input.name}),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["categories"] });
+      qc.invalidateQueries({ queryKey: ["category", id] });
+      nav(`/categories/${id}`);
+    },
+  });
+
+  if (isLoading) return <p className="p-4">Carregando...</p>;
+  if (error || !data) return <p className="p-4 text-red-500">Categoria não encontrada.</p>;
+
+  return (
+    <div className="p-6 max-w-lg mx-auto space-y-4">
+      <h1 className="text-2xl font-semibold">Editar categoria</h1>
+      <CategoryForm
+        defaultValues={{ name: data.name }}
+        submitting={isPending}
+        submitLabel="Salvar alterações"
+        onSubmit={async (payload) => { await mutateAsync({ id, ...payload }); }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/services/categories.ts
+++ b/frontend/src/services/categories.ts
@@ -1,0 +1,27 @@
+import { api } from "./api";
+import type { Category, CategoryInput } from "types/category";
+
+export async function listCategories() {
+  const { data } = await api.get<Category[]>("/categories");
+  return data;
+}
+
+export async function getCategory(id: string | number) {
+  const { data } = await api.get<Category>(`/categories/${id}`);
+  return data;
+}
+
+export async function createCategory(input: CategoryInput) {
+  const { data } = await api.post<Category>("/categories", input);
+  return data;
+}
+
+export async function updateCategory(id: string | number, input: CategoryInput) {
+  const { data } = await api.put<Category>(`/categories/${id}`, input);
+  return data;
+}
+
+export async function deleteCategory(id: string | number) {
+  await api.delete(`/categories/${id}`);
+  return true;
+}

--- a/frontend/src/types/category.ts
+++ b/frontend/src/types/category.ts
@@ -1,0 +1,8 @@
+export type Category = {
+  id: string | number;
+  name: string;
+};
+
+export type CategoryInput = {
+  name: string;
+};


### PR DESCRIPTION
## O que foi feito
- Páginas: **/categories** (lista), **/categories/new**, **/categories/:id**, **/categories/:id/edit**.
- **Protegidas** por `ProtectedRoute` (só acessa logado).
- **React Query** para fetch/cache e invalidação.
- **React Hook Form + Zod** no form de categoria.
- **Axios** já usa token via interceptor (herdado do auth).

## Endpoints usados
- `GET /categories`
- `POST /categories`
- `PUT /categories/:id`
- `DELETE /categories/:id`

## Como testar
1. Faça login.
2. Vá em **/categories**:
   - Criar: botão “Nova categoria”.
   - Editar: botão “Editar”.
   - Excluir: botão “Excluir” (confirmação).
3. Recarregue a lista para ver cache/invalidations funcionando.

## Arquivos principais
- `src/services/categories.ts`
- `src/types/category.ts`
- `src/components/forms/CategoryForm.tsx`
- `src/pages/categories/*`
- `src/app/routes.tsx`
