### PR TITLE
[FEAT] add Product CRUD with category relation 

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,7 +25,7 @@
         "react-router-dom": "^7.8.2",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
-        "zod": "^4.1.5",
+        "zod": "3.25.76",
         "zustand": "^5.0.8"
       },
       "devDependencies": {
@@ -5486,9 +5486,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.5.tgz",
-      "integrity": "sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,7 +27,7 @@
     "react-router-dom": "^7.8.2",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^4.1.5",
+    "zod": "3.25.76",
     "zustand": "^5.0.8"
   },
   "devDependencies": {

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -6,6 +6,10 @@ import { ProtectedRoute } from "@lib/router/ProtectedRoute";
 import CategoriesList from "@pages/categories/CategoriesList";
 import CategoryCreate from "@pages/categories/CategoryCreate";
 import CategoryEdit from "@pages/categories/CategoryEdit";
+import ProductsList from "@pages/products/ProductsList";
+import ProductCreate from "@pages/products/ProductCreate";
+import ProductEdit from "@pages/products/ProductEdit";
+
 
 export function AppRoutes() {
   return (
@@ -46,6 +50,31 @@ export function AppRoutes() {
           element={
             <ProtectedRoute>
               <CategoryEdit />
+            </ProtectedRoute>
+          }
+        />
+
+        <Route
+          path="/products"
+          element={
+            <ProtectedRoute>
+              <ProductsList />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/products/new"
+          element={
+            <ProtectedRoute>
+              <ProductCreate />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/products/:id/edit"
+          element={
+            <ProtectedRoute>
+              <ProductEdit />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/components/ui/forms/ProductForm.tsx
+++ b/frontend/src/components/ui/forms/ProductForm.tsx
@@ -1,0 +1,112 @@
+import { useForm, type SubmitHandler } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useQuery } from "@tanstack/react-query";
+import { listCategories } from "@services/categories";
+import { Button } from "@components/ui/button";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+
+const schema = z.object({
+  name: z.string().min(2, "Informe o nome"),
+  description: z.string().optional(),
+  price: z.coerce.number().positive("Preço deve ser > 0"),
+  quantity: z.coerce.number().int().nonnegative("Quantidade deve ser >= 0"),
+  categoryId: z.coerce.number().positive("Selecione uma categoria"),
+});
+type FormData = z.infer<typeof schema>;
+
+type Props = {
+  defaultValues?: Partial<FormData>;
+  onSubmit: SubmitHandler<FormData>;
+  submitting?: boolean;
+  submitLabel?: string;
+};
+
+export function ProductForm({
+  defaultValues,
+  onSubmit,
+  submitting,
+  submitLabel = "Salvar",
+}: Props) {
+  const { data: categories, isLoading: loadingCats } = useQuery({
+    queryKey: ["categories"],
+    queryFn: listCategories,
+  });
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData, any, FormData>({
+    resolver: zodResolver<FormData, any, FormData>(schema),
+    defaultValues,
+  });
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <Label>Nome</Label>
+          <Input {...register("name")} placeholder="Ex: Albumina em Pó" />
+          {errors.name && <p className="text-sm text-red-500">{errors.name.message}</p>}
+        </div>
+
+        <div className="space-y-2">
+          <Label>Preço</Label>
+          <Input
+            type="number"
+            step="0.01"
+            {...register("price", { valueAsNumber: true })}
+            placeholder="59.90"
+          />
+          {errors.price && <p className="text-sm text-red-500">{errors.price.message}</p>}
+        </div>
+
+        <div className="space-y-2">
+          <Label>Quantidade</Label>
+          <Input
+            type="number"
+            {...register("quantity", { valueAsNumber: true })}
+            placeholder="70"
+          />
+          {errors.quantity && <p className="text-sm text-red-500">{errors.quantity.message}</p>}
+        </div>
+
+        <div className="space-y-2">
+          <Label>Categoria</Label>
+          <select
+            className="w-full rounded-md border bg-transparent p-2"
+            disabled={loadingCats}
+            {...register("categoryId", {
+              setValueAs: (v) => (v === "" ? undefined : Number(v)),
+            })}
+          >
+            <option value="" hidden>Selecione…</option>
+            {categories?.map((c) => (
+              <option key={c.id} value={String(c.id)} className="text-foreground bg-background">
+                {c.name} (#{c.id})
+              </option>
+            ))}
+          </select>
+          {errors.categoryId && (
+            <p className="text-sm text-red-500">{errors.categoryId.message}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label>Descrição (opcional)</Label>
+        <textarea
+          className="w-full rounded-md border p-2 min-h-24 bg-transparent"
+          placeholder="Proteína de absorção lenta, ideal para antes de dormir."
+          {...register("description")}
+        />
+      </div>
+
+      <Button type="submit" disabled={submitting} className="w-full">
+        {submitting ? "Enviando..." : submitLabel}
+      </Button>
+    </form>
+  );
+}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -11,6 +11,8 @@ export default function Home() {
     <div className="min-h-screen grid place-items-center p-6 text-center space-y-4">
       <h1 className="text-2xl font-semibold">Bem-vindo{user ? `, ${user.name}` : ""}!</h1>
       <Button asChild><Link to="/categories">Ir para categorias</Link></Button>
+      <Button asChild className="mt-2"><Link to="/products">Ir para produtos</Link></Button>
+
       <Button
         variant="outline"
         onClick={() => {

--- a/frontend/src/pages/products/ProductCreate.tsx
+++ b/frontend/src/pages/products/ProductCreate.tsx
@@ -1,0 +1,34 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createProduct } from "@services/products";
+import { ProductForm } from "@components/ui/forms/ProductForm";
+import { useNavigate, Link } from "react-router-dom";
+import { Button } from "@components/ui/button";
+
+export default function ProductCreate() {
+  const qc = useQueryClient();
+  const nav = useNavigate();
+
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: createProduct,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["products"] });
+      nav("/products");
+    },
+  });
+
+  return (
+    <div className="p-6 max-w-2xl mx-auto space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Novo produto</h1>
+        <Button asChild variant="outline"><Link to="/products">Voltar</Link></Button>
+      </div>
+      <ProductForm
+        submitting={isPending}
+        onSubmit={async (data) => {
+          await mutateAsync(data);
+        }}
+        submitLabel="Criar"
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/products/ProductEdit.tsx
+++ b/frontend/src/pages/products/ProductEdit.tsx
@@ -1,0 +1,50 @@
+import { useParams, useNavigate, Link } from "react-router-dom";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getProduct, updateProduct } from "@services/products";
+import { ProductForm } from "@components/ui/forms/ProductForm";
+import { Button } from "@components/ui/button";
+
+export default function ProductEdit() {
+  const { id = "" } = useParams();
+  const nav = useNavigate();
+  const qc = useQueryClient();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["product", id],
+    queryFn: () => getProduct(id),
+  });
+
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: (input: any) => updateProduct(id, input),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["products"] });
+      qc.invalidateQueries({ queryKey: ["product", id] });
+      nav(`/products/${id}`);
+    },
+  });
+
+  if (isLoading) return <p className="p-4">Carregando...</p>;
+  if (error || !data) return <p className="p-4 text-red-500">Produto não encontrado.</p>;
+
+  return (
+    <div className="p-6 max-w-2xl mx-auto space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Editar produto</h1>
+        <Button asChild variant="outline"><Link to={`/products/${id}`}>Cancelar</Link></Button>
+      </div>
+
+      <ProductForm
+        defaultValues={{
+          name: data.name,
+          description: data.description,
+          price: data.price,
+          quantity: data.quantity,
+          categoryId: Number(data.category?.id),
+        }}
+        submitting={isPending}
+        submitLabel="Salvar alterações"
+        onSubmit={async (payload) => { await mutateAsync({ id, ...payload }); }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/products/ProductsList.tsx
+++ b/frontend/src/pages/products/ProductsList.tsx
@@ -1,0 +1,78 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { listProducts, deleteProduct } from "@services/products";
+import { Link, useNavigate } from "react-router-dom";
+import { Button } from "@components/ui/button";
+
+export default function ProductsList() {
+  const qc = useQueryClient();
+  const nav = useNavigate();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["products"],
+    queryFn: listProducts,
+  });
+
+  const { mutateAsync: remove, isPending: removing } = useMutation({
+    mutationFn: (id: string | number) => deleteProduct(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["products"] }),
+  });
+
+  if (isLoading) return <p className="p-4">Carregando...</p>;
+  if (error) return <p className="p-4 text-red-500">Erro ao carregar produtos</p>;
+
+  return (
+    <div className="p-6 space-y-4 max-w-5xl mx-auto">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Produtos</h1>
+        <Button onClick={() => nav("/products/new")}>Novo produto</Button>
+      </div>
+
+      {!data?.length ? (
+        <p className="text-sm text-muted-foreground">Nenhum produto cadastrado.</p>
+      ) : (
+        <div className="overflow-x-auto border rounded-lg">
+          <table className="w-full text-left">
+            <thead className="bg-muted/40">
+              <tr>
+                <th className="p-3">ID</th>
+                <th className="p-3">Nome</th>
+                <th className="p-3">Preço</th>
+                <th className="p-3">Qtd</th>
+                <th className="p-3">Categoria</th>
+                <th className="p-3 w-56">Ações</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.map((p) => (
+                <tr key={p.id} className="border-t">
+                  <td className="p-3">{p.id}</td>
+                  <td className="p-3">{p.name}</td>
+                  <td className="p-3">R$ {Number(p.price).toFixed(2)}</td>
+                  <td className="p-3">{p.quantity}</td>
+                  <td className="p-3">{p.category?.name ?? `#${p.category?.id ?? "-"}`}</td>
+                  <td className="p-3 space-x-2">
+                    <Button variant="outline" size="sm" asChild>
+                      <Link to={`/products/${p.id}/edit`}>Editar</Link>
+                    </Button>
+                    <Button
+                      variant="destructive"
+                      size="sm"
+                      disabled={removing}
+                      onClick={async () => {
+                        if (confirm(`Excluir produto "${p.name}"?`)) {
+                          await remove(p.id);
+                        }
+                      }}
+                    >
+                      Excluir
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/services/products.ts
+++ b/frontend/src/services/products.ts
@@ -1,0 +1,35 @@
+import { api } from "./api";
+import type { Product, ProductInput } from "types/product";
+
+const toPayload = (input: ProductInput) => ({
+  name: input.name,
+  description: input.description,
+  price: Number(input.price),
+  quantity: Number(input.quantity),
+  category: { id: Number(input.categoryId) },
+});
+
+export async function listProducts() {
+  const { data } = await api.get<Product[]>("/products");
+  return data;
+}
+
+export async function getProduct(id: string | number) {
+  const { data } = await api.get<Product>(`/products/${id}`);
+  return data;
+}
+
+export async function createProduct(input: ProductInput) {
+  const { data } = await api.post<Product>("/products", toPayload(input));
+  return data;
+}
+
+export async function updateProduct(id: string | number, input: ProductInput) {
+  const { data } = await api.put<Product>(`/products/${id}`, toPayload(input));
+  return data;
+}
+
+export async function deleteProduct(id: string | number) {
+  await api.delete(`/products/${id}`);
+  return true;
+}

--- a/frontend/src/types/product.ts
+++ b/frontend/src/types/product.ts
@@ -1,0 +1,20 @@
+import type { Category } from "types/category";
+
+export type Product = {
+  id: string | number;
+  name: string;
+  description?: string;
+  price: number;
+  quantity: number;
+  category?: Pick<Category, "id" | "name">;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+export type ProductInput = {
+  name: string;
+  description?: string;
+  price: number;
+  quantity: number;
+  categoryId: number;
+};


### PR DESCRIPTION
## Resumo
Este PR adiciona um CRUD completo de **Produtos**, atrás de autenticação:
- Páginas: **/products**, **/products/new**, **/products/:id/edit**
- Formulário com **seleção de categoria** (obrigatória)
- **React Query** para busca/cache e invalidação
- **React Hook Form + Zod** para formulários e validação
- **Axios** com interceptors (autenticação)
- Todas as rotas de produtos são **protegidas** por `ProtectedRoute`

## Contrato do Backend
**Endpoints utilizados**
- `GET /products`
- `POST /products`
- `PUT /products/:id`
- `DELETE /products/:id`
